### PR TITLE
Allow Okta "push" choice to be pre-recorded in .okta-aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 **/*.pyc
 **/.DS_Store
-dist
 *.egg-info
+build
+dist
+install

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ base-url = <your_okta_org>.okta.com
 username = <your_okta_username>
 password = <your_okta_password> # Only save your password if you know what you are doing!
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
+factor-type = <your_preferred_mfa_type> # Set to "push" to enable Okta push notifications, or leave out
 ```
 
 ## Supported Features

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -40,6 +40,10 @@ class OktaAuth(object):
             self.factor = parser.get(profile, 'factor')
             self.logger.debug("Setting MFA factor to %s" % self.factor)
 
+        if parser.has_option(profile, 'factor-type'):
+            self.factor_type = parser.get(profile, 'factor-type')
+            self.logger.debug("Setting MFA factor type to %s" % self.factor_type)
+
         self.verbose = verbose
 
     def primary_auth(self):
@@ -105,7 +109,8 @@ class OktaAuth(object):
 
                 if self.factor:
                     if self.factor == factor_provider:
-                        factor_choice = index
+                        factor_choice = index + 1
+                        self.logger.info("Using factor type: %s" % factor_name)
                         self.logger.info("Using pre-selected factor choice \
                                          from ~/.okta-aws")
                         break


### PR DESCRIPTION
Allow developers to specify `factor-type = push` in their .okta-aws file to bypass the prompt asking to choose between the different MFA types.